### PR TITLE
Overflow for large number of tests

### DIFF
--- a/perf-tester.js
+++ b/perf-tester.js
@@ -322,7 +322,7 @@
           <b>${timeReport}</b>
           &nbsp;&nbsp;<a href="${this.base}${url}" target="_blank">${title}</a>
           <br>
-          <span style="font-size: 8px; white-space: nowrap">`;
+          <span style="font-size: 8px;white-space: nowrap;overflow-x: auto;display: block;">`;
         //
         for (let j=0, v; (v=times[j]); j++) {
           max = Math.max(v, max);


### PR DESCRIPTION
If you have a lot of tests, the span starts to overflow. However, you can not inspect the actual values. Therefore the span requires display block to correctly overflow-x for a lot of test results.