### PR TITLE
Fix display of zero values

### DIFF
--- a/perf-tester.js
+++ b/perf-tester.js
@@ -324,7 +324,7 @@
           <br>
           <span style="font-size: 8px; white-space: nowrap">`;
         //
-        for (let j=0, v; (v=times[j]); j++) {
+        for (let j=0, v; (v=times[j]) !== undefined; j++) {
           max = Math.max(v, max);
           let o = stats.outlier(v);
           info += (o ? '<o>' : '<n>') + v.toFixed(0) + (o ? '</o>' : '</n>') + '|';


### PR DESCRIPTION
If a test took <1 ms, the times would not be shown in the result span. The stop-condition of the for-loop should not be falsy, but explicitly require to not be undefined.