### PR TITLE
Remove WebComponentsReady listener in demo

### DIFF
--- a/demo/runner.html
+++ b/demo/runner.html
@@ -17,14 +17,11 @@
   <summary>Perf is go.</summary>
   <perf-tester></perf-tester>
 
-  <script>
-  addEventListener('WebComponentsReady', function() {
+  <script type="module">
     document.querySelector('perf-tester').tests = [
       'a.html',
       'input.html'
     ];
-
-  });
   </script>
 
 </body>


### PR DESCRIPTION
If we're not using HTML Imports, we don't need it, as long as scripts that depend on loaded elements are modules or defered, right?