### PR TITLE
fix: prevent NaN results

### DIFF
--- a/perf-tester.js
+++ b/perf-tester.js
@@ -282,6 +282,9 @@
 
     _scoreMessage(e) {
       if (this.afterScore) {
+        if (!e.data) {
+          return;
+        }
         let info = e.data;
         if (typeof info !== 'object') {
           info = {time: info};


### PR DESCRIPTION
Sometimes the message event gets triggered by something else. As as a result there are events with empty data - they can simple be ignored.

fixes #7 