### PR TITLE
fix: NaN time reports

### DIFF
--- a/perf-tester.js
+++ b/perf-tester.js
@@ -282,7 +282,7 @@
 
     _scoreMessage(e) {
       if (this.afterScore) {
-        if (!e.data) {
+        if (!e.data || !e.data.time) {
           return;
         }
         let info = e.data;


### PR DESCRIPTION
Should completely fix https://github.com/PolymerLabs/perf-tester/issues/7

`e.data` is sometimes an object containing `time` which makes the actual check for data presence a bit more complicated than this https://github.com/PolymerLabs/perf-tester/pull/8/files , although they are both necessary